### PR TITLE
Codespaces Port forwarding URL support

### DIFF
--- a/src/web-app/env-config.js
+++ b/src/web-app/env-config.js
@@ -9,6 +9,15 @@ const {
 
 const appUrl = `http://localhost:${PORT}`;
 
+function checkEnvironment(){
+  // Use the Codespace App URL if we're in the Codespace environment
+  if(process.env.CODESPACE_NAME){
+    return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+  }
+  // otherwise use the localhost App URL
+  return appUrl;
+}
+
 function checkUrl() {
   return (req, res, next) => {
     const host = req.headers.host;
@@ -38,7 +47,7 @@ console.log('----------------------------------\n');
 
 module.exports = {
   checkUrl,
-  APP_URL: appUrl,
+  APP_URL: checkEnvironment(),
   API_URL: removeTrailingSlashFromUrl(API_URL),
   ISSUER_BASE_URL: removeTrailingSlashFromUrl(ISSUER_BASE_URL),
   CLIENT_ID: CLIENT_ID,


### PR DESCRIPTION
When codespaces env is detected, pass the codespaces URL as APP_URL to auth middleware for callback to work


### Testing
#### Test Codespaces env
1. Fork this branch to your Github account
2. Open your fork with Codespaces
3. Follow the CodeTour as normal (Note that you will need to add the Codespaces port forwarding URL in the PORTS tab to the Allowed Callback and Logout URLs rather than localhost--the correct URL is also printed in the debugging console when you launch the app)
4. Added `checkEnvironment()` function in `env-config.js` will construct the Codespaces port forwarding URL (based on the condition that we are in Codespaces) and export this value as APP_URL, which is passed to the auth middleware in `index.js`.
5. Note: The embedded URL rendered in the CodeTour step by the Auth0 labs extension will be incorrect, but the link in the PORTS tab and printed to the debugger will be the correct link. There's an open Auth0 labs extension issue we can look into so that the URL in the CodeTour will be correct regardless of environment: https://github.com/auth0-training/labs-vscode-extension/issues/35

#### Test local env
Since it's also important to test that this change didn't break anything for learners completing this training on their local machine, run through the lab as normal on your local machine to ensure everything works as expected.

